### PR TITLE
parameterized attributes

### DIFF
--- a/examples/optimized-mssql-example/main.tf
+++ b/examples/optimized-mssql-example/main.tf
@@ -1,9 +1,11 @@
 module "optimized-mssql-managed-instance" {
   mi_name                      = "terraformtestingexample"
   source                       = "intel/azure-mssql-managed-instance/intel"
+  azurerm_resource_group_name  = "<ENTER_MI_RESOURCE_GROUP>"
+  subnet_resource_group_name   = "<ENTER_MI_SUBNET_RESOURCE_GROUP>"
+  azurerm_virtual_network_name = "<ENTER_VIRTUAL_NETWORK_NAME>"
   azurerm_subnet_name          = "<ENTER_SUBNET_NAME>"
-  nsg_name                     = "<ENTER_NETWORK_SECURITY_GROUP_NAME>"
-  azurerm_virtual_network_name = "<ENTER VIRTUAL NETWORK>"
+  nsg_name                     = "<ENTER_NSG_NAME>"
   administrator_login_password = var.administrator_login_password
   administrator_login          = "sqladmin"
   license_type                 = "BasePrice"

--- a/main.tf
+++ b/main.tf
@@ -4,13 +4,13 @@ data "azurerm_resource_group" "rg" {
 
 data "azurerm_virtual_network" "vnet" {
   name                = var.azurerm_virtual_network_name
-  resource_group_name = var.azurerm_resource_group_name
+  resource_group_name = var.subnet_resource_group_name
 }
 
 data "azurerm_subnet" "subnet" {
   name                 = var.azurerm_subnet_name
   virtual_network_name = data.azurerm_virtual_network.vnet.name
-  resource_group_name  = data.azurerm_resource_group.rg.name
+  resource_group_name  = var.subnet_resource_group_name
 }
 
 data "azurerm_network_security_group" "nsg" {
@@ -29,7 +29,12 @@ resource "azurerm_mssql_managed_instance" "mssql_managed_instance" {
   vcores                       = var.vcore_count
   license_type                 = var.license_type
   subnet_id                    = data.azurerm_subnet.subnet.id
-  tags                         = var.tags
+  storage_account_type         = var.storage_account_type
+  identity {
+    type         = var.identity_type
+    identity_ids = var.identity_type == "UserAssigned" ? var.user_assigned_identity_ids : []
+  }
+  tags = var.tags
 
   timeouts {
     create = "6h"

--- a/variables.tf
+++ b/variables.tf
@@ -51,7 +51,12 @@ variable "administrator_login_password" {
 }
 
 variable "azurerm_resource_group_name" {
-  description = "Name of the resource group to be imported"
+  description = "Name of the resource group in which the instance needs to be deployed"
+  type        = string
+}
+
+variable "subnet_resource_group_name" {
+  description = "Name of resource group that contains the subnet in which the instance needs to be deployed"
   type        = string
 }
 
@@ -63,7 +68,6 @@ variable "azurerm_virtual_network_name" {
 variable "azurerm_subnet_name" {
   description = "The name of the preconfigured subnet"
   type        = string
-
 }
 
 variable "nsg_name" {
@@ -86,4 +90,21 @@ variable "tags" {
   type        = map(any)
   default = {
   }
+}
+
+variable "storage_account_type" {
+  description = "Storage account type to store backups"
+  default     = null
+}
+
+variable "identity_type" {
+  description = "Type of managed identity to set"
+  type        = string
+  default     = null
+}
+
+variable "user_assigned_identity_ids" {
+  description = "List of user-assigned managed identity IDs"
+  type        = list(string)
+  default     = []
 }


### PR DESCRIPTION
Hello Team,

We tested the module and have identified a few changes that we would like to implement. We believe that these enhancements will not only improve the module but also ensure it is versatile and compatible with different use cases that end users may encounter. These updates will allow for more effective internal usage.

CR#1
Adding **managed identity** attribute, both "SystemAssigned " and "UserAssigned",  into the scope with flexibility i.e. by parameterizing the same and keeping it optional.

CR#2
Adding **storage account type** attribute into the scope. The same is parameterized and is made optional.

CR#3
In the current module, a single resource group is utilized to deploy every component of the managed instance.
However, we have grouped the network components into one resource group and we want to deploy the instance into another resource group for reasons. The current data source blocks structure within the module does not go well with this scenario.
Hence added another **variable** named **subnet_resource_group_name** which gives room to use specific value for network components of the instance. Necessary changes as been made in data source blocks. 
The code structure is preserved while enhancing flexibility.

We hope these changes are considered.

Looking forward to use the module with the changes.

Thanks & Regards,
Ankitha 